### PR TITLE
Update regex to account for domain name conventions

### DIFF
--- a/poetry_codeartifact_plugin/plugin.py
+++ b/poetry_codeartifact_plugin/plugin.py
@@ -12,7 +12,7 @@ from poetry.poetry import Poetry
 from poetry.utils.authenticator import Authenticator
 
 RE_CODEARTIFACT_NETLOC = re.compile(
-    r"^([a-z-]+)-(\d+)\.d\.codeartifact\.[^.]+\.amazonaws\.com$"
+    r"^([a-z][a-z-]+)-(\d+)\.d\.codeartifact\.[^.]+\.amazonaws\.com$"
 )
 
 

--- a/poetry_codeartifact_plugin/plugin.py
+++ b/poetry_codeartifact_plugin/plugin.py
@@ -12,7 +12,7 @@ from poetry.poetry import Poetry
 from poetry.utils.authenticator import Authenticator
 
 RE_CODEARTIFACT_NETLOC = re.compile(
-    r"^([^-]+)-(\d+)\.d\.codeartifact\.[^.]+\.amazonaws\.com$"
+    r"^([a-z-]+)-(\d+)\.d\.codeartifact\.[^.]+\.amazonaws\.com$"
 )
 
 

--- a/poetry_codeartifact_plugin/plugin.py
+++ b/poetry_codeartifact_plugin/plugin.py
@@ -12,7 +12,7 @@ from poetry.poetry import Poetry
 from poetry.utils.authenticator import Authenticator
 
 RE_CODEARTIFACT_NETLOC = re.compile(
-    r"^([a-z][a-z-]+)-(\d+)\.d\.codeartifact\.[^.]+\.amazonaws\.com$"
+    r"^([a-z][a-z-]*)-(\d+)\.d\.codeartifact\.[^.]+\.amazonaws\.com$"
 )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-codeartifact-plugin"
-version = "1.0.1"
+version = "1.0.2"
 description = "A poetry plugin for keeping your CodeArtifact authorization token up-to-date"
 authors = ["Tom Petr <tom@r2c.dev>"]
 readme = "README.md"


### PR DESCRIPTION
This PR updates the CodeArtifact URL regex to match the documented domain naming conventions. Here are the naming conventions given in the CodeArtifact console:

> Must start with a lowercase letter. Can contain lowercase alphanumeric characters or dashes (-).

Previously, the regex excluded domain names with the `-` character in them, which rejects valid domain names. This new regex correctly matches  the listed requirements.